### PR TITLE
Integrate two castlewall HP logic

### DIFF
--- a/Assets/Scenes/Defense.unity
+++ b/Assets/Scenes/Defense.unity
@@ -3440,6 +3440,58 @@ MonoBehaviour:
     m_Bits: 256
   playerObjCircle: {fileID: 2579837272745347421, guid: e3f3eb61d64936d41a8775cb9f69e009,
     type: 3}
+--- !u!1 &370809723
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 370809724}
+  - component: {fileID: 370809725}
+  m_Layer: 0
+  m_Name: Wall HP Controller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &370809724
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 370809723}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 83.98998, y: 12.799654, z: 1.3820719}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 734595523}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &370809725
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 370809723}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6d05be8185cf431ab9256b7c00297140, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHealth: 3000
+  activateShieldValue: 100
+  health: 0
+  shield: 0
+  activateShield: 0
+  healthSlider: {fileID: 1016381815}
+  shieldSlider: {fileID: 1462641434}
+  hasShield: 0
 --- !u!1 &432860099
 GameObject:
   m_ObjectHideFlags: 0
@@ -4229,18 +4281,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bb0ff1a607b6b464dbf533d521336d19, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxHealth: 2000
-  health: 2000
-  maxShield: 100
-  shield: 0
   gameOverCanvas: {fileID: 971673594}
   gameOverImage: {fileID: 491734050}
   gameOverButton: {fileID: 607689188}
-  healthSlider: {fileID: 1016381815}
-  shieldSlider: {fileID: 1462641434}
-  hasShield: 0
-  activateShield: 0
-  activateShieldValue: 80
 --- !u!1 &491734048
 GameObject:
   m_ObjectHideFlags: 0
@@ -6426,6 +6469,7 @@ Transform:
   m_Children:
   - {fileID: 2043143692}
   - {fileID: 1155641489}
+  - {fileID: 370809724}
   - {fileID: 660744211}
   - {fileID: 1832681954}
   - {fileID: 773175654}
@@ -8403,18 +8447,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bb0ff1a607b6b464dbf533d521336d19, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxHealth: 2000
-  health: 2000
-  maxShield: 100
-  shield: 0
   gameOverCanvas: {fileID: 971673594}
   gameOverImage: {fileID: 491734050}
   gameOverButton: {fileID: 607689188}
-  healthSlider: {fileID: 0}
-  shieldSlider: {fileID: 0}
-  hasShield: 0
-  activateShield: 0
-  activateShieldValue: 80
 --- !u!66 &1340186573
 CompositeCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Defense.unity
+++ b/Assets/Scenes/Defense.unity
@@ -2431,10 +2431,10 @@ MonoBehaviour:
       m_Calls: []
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 10
+    m_FontSize: 20
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 1
+    m_MinSize: 0
     m_MaxSize: 40
     m_Alignment: 4
     m_AlignByGeometry: 0
@@ -3484,7 +3484,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d05be8185cf431ab9256b7c00297140, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxHealth: 3000
+  maxHealth: 100
   activateShieldValue: 100
   health: 0
   shield: 0
@@ -3492,6 +3492,9 @@ MonoBehaviour:
   healthSlider: {fileID: 1016381815}
   shieldSlider: {fileID: 1462641434}
   hasShield: 0
+  gameOverCanvas: {fileID: 971673594}
+  gameOverImage: {fileID: 491734050}
+  gameOverButton: {fileID: 607689188}
 --- !u!1 &432860099
 GameObject:
   m_ObjectHideFlags: 0
@@ -4281,9 +4284,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bb0ff1a607b6b464dbf533d521336d19, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  gameOverCanvas: {fileID: 971673594}
-  gameOverImage: {fileID: 491734050}
-  gameOverButton: {fileID: 607689188}
 --- !u!1 &491734048
 GameObject:
   m_ObjectHideFlags: 0
@@ -5284,8 +5284,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -34.427124}
-  m_SizeDelta: {x: 100, y: 31.1458}
+  m_AnchoredPosition: {x: 31.3, y: -19.8}
+  m_SizeDelta: {x: 248.4031, y: 55.4457}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &607689188
 MonoBehaviour:
@@ -8447,9 +8447,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bb0ff1a607b6b464dbf533d521336d19, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  gameOverCanvas: {fileID: 971673594}
-  gameOverImage: {fileID: 491734050}
-  gameOverButton: {fileID: 607689188}
 --- !u!66 &1340186573
 CompositeCollider2D:
   m_ObjectHideFlags: 0
@@ -17399,13 +17396,23 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1132482028413179668, guid: f490398be12f54440ae29229b381ef74,
         type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 246.3844
+      objectReference: {fileID: 0}
+    - target: {fileID: 1132482028413179668, guid: f490398be12f54440ae29229b381ef74,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 52.1499
+      objectReference: {fileID: 0}
+    - target: {fileID: 1132482028413179668, guid: f490398be12f54440ae29229b381ef74,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 11
+      value: 32.429993
       objectReference: {fileID: 0}
     - target: {fileID: 1132482028413179668, guid: f490398be12f54440ae29229b381ef74,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -107
+      value: -113
       objectReference: {fileID: 0}
     - target: {fileID: 1549546617971528292, guid: f490398be12f54440ae29229b381ef74,
         type: 3}
@@ -17507,10 +17514,35 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3924667624631022523, guid: f490398be12f54440ae29229b381ef74,
+        type: 3}
+      propertyPath: m_FontData.m_MinSize
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3924667624631022523, guid: f490398be12f54440ae29229b381ef74,
+        type: 3}
+      propertyPath: m_FontData.m_FontSize
+      value: 20
+      objectReference: {fileID: 0}
     - target: {fileID: 6378500672925298018, guid: f490398be12f54440ae29229b381ef74,
         type: 3}
       propertyPath: m_Name
       value: StageClearUI Canvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 6450280239625820882, guid: f490398be12f54440ae29229b381ef74,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6450280239625820882, guid: f490398be12f54440ae29229b381ef74,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6450280239625820882, guid: f490398be12f54440ae29229b381ef74,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/Scenes/Defense.unity
+++ b/Assets/Scenes/Defense.unity
@@ -3484,7 +3484,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6d05be8185cf431ab9256b7c00297140, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxHealth: 100
+  maxHealth: 200
   activateShieldValue: 100
   health: 0
   shield: 0
@@ -3492,9 +3492,6 @@ MonoBehaviour:
   healthSlider: {fileID: 1016381815}
   shieldSlider: {fileID: 1462641434}
   hasShield: 0
-  gameOverCanvas: {fileID: 971673594}
-  gameOverImage: {fileID: 491734050}
-  gameOverButton: {fileID: 607689188}
 --- !u!1 &432860099
 GameObject:
   m_ObjectHideFlags: 0
@@ -6467,6 +6464,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1661714312}
   - {fileID: 2043143692}
   - {fileID: 1155641489}
   - {fileID: 370809724}
@@ -15306,6 +15304,53 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1660223211}
   m_CullTransparentMesh: 1
+--- !u!1 &1661714311
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1661714312}
+  - component: {fileID: 1661714313}
+  m_Layer: 0
+  m_Name: Stage Controller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1661714312
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1661714311}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -7.1959314, y: 103.8963, z: 6.5053287}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 734595523}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1661714313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1661714311}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 238f93112c684bf1b27abfdd679508a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gameOverCanvas: {fileID: 971673594}
+  gameOverImage: {fileID: 491734050}
+  gameOverButton: {fileID: 607689188}
 --- !u!1 &1687641369
 GameObject:
   m_ObjectHideFlags: 0
@@ -26914,7 +26959,7 @@ MonoBehaviour:
   - {fileID: 1839222284020890419, guid: ecbf48371fd6b7a43a609b4f84b7f769, type: 3}
   rightMinY: -20
   rightMaxY: 120
-  numberOfObjects: 50
+  numberOfObjects: 10
   maxSpawnInterval: 2
   totalWave: 3
   bossPrefab: {fileID: 1839222284020890419, guid: faba8c4131a548641a1957130c739343,

--- a/Assets/Scripts/DefenseScripts/CastleWall.cs
+++ b/Assets/Scripts/DefenseScripts/CastleWall.cs
@@ -1,15 +1,10 @@
 using System.Collections;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using UnityEngine.Tilemaps;
-using UnityEngine.UI;
 
 public class CastleWall : MonoBehaviour
 {
-    [SerializeField] private Canvas gameOverCanvas;
-    [SerializeField] private Image gameOverImage;
-    [SerializeField] private Button gameOverButton;
-
+    //CastleWall 클래스는 성벽이 데미지를 받을 때 CastleWallManager에 처리를 위임하고, 성벽 오브젝트를 삭제하는 역할만 담당
     private Tilemap castleTile;
     private Color originColor;
 
@@ -17,30 +12,6 @@ public class CastleWall : MonoBehaviour
     {
         castleTile = GetComponent<Tilemap>();
         originColor = castleTile.color;
-
-        if (gameOverImage != null)
-        {
-            gameOverImage.gameObject.SetActive(false);
-        }
-    }
-
-    private void Start()
-    {
-        if (gameOverCanvas != null)
-        {
-            gameOverCanvas.enabled = false;
-        }
-
-        if (gameOverImage != null)
-        {
-            gameOverImage.enabled = false;
-        }
-
-        if (gameOverButton != null)
-        {
-            gameOverButton.enabled = false;
-            gameOverButton.onClick.AddListener(OnGameOverButtonClick);
-        }
     }
 
     public void TakeDamage(float damage)
@@ -49,8 +20,7 @@ public class CastleWall : MonoBehaviour
 
         if (CastleWallManager.Instance.GetHealth() <= 0)
         {
-            ShowGameOverUI();
-            Destroy(gameObject);
+            Destroy(gameObject);  // 성벽 오브젝트 삭제
         }
     }
 
@@ -71,19 +41,5 @@ public class CastleWall : MonoBehaviour
         {
             castleTile.color = originColor;
         }
-    }
-
-    private void ShowGameOverUI()
-    {
-        Debug.Log("게임오버 UI 출현");
-        gameOverCanvas.enabled = true;
-        gameOverImage.enabled = true;
-        gameOverButton.enabled = true;
-    }
-
-    public void OnGameOverButtonClick()
-    {
-        Debug.Log("버튼 클릭됨");
-        SceneManager.LoadScene("Title");
     }
 }

--- a/Assets/Scripts/DefenseScripts/CastleWall.cs
+++ b/Assets/Scripts/DefenseScripts/CastleWall.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -7,59 +6,26 @@ using UnityEngine.UI;
 
 public class CastleWall : MonoBehaviour
 {
-    [SerializeField] public float maxHealth = 3000; // 성벽의 최대 체력
-    [SerializeField] public float health; // 성벽의 현재 체력
-    [SerializeField] public float maxShield = 1000; // 실드의 최대 값
-    [SerializeField] public float shield; // 현재 실드 값
-
-    [SerializeField] private Canvas gameOverCanvas; // 겜오버 캔버스 참조변수
-    [SerializeField] private Image gameOverImage; // 겜오버 이미지 참조변수
-    [SerializeField] private Button gameOverButton; // 겜오버 버튼 참조변수
-    [SerializeField] private Slider healthSlider; // 체력 슬라이더 참조변수
-    [SerializeField] private Slider shieldSlider; // 실드 슬라이더 참조변수
-
-    public bool hasShield; // hasShield를 public으로 유지
-
-    [SerializeField] private bool activateShield;
-    [SerializeField] private float activateShieldValue = 80f; // ActivateShield 메서드에서 설정할 실드 값
-
-    private Coroutine earnShieldCoroutine;
+    [SerializeField] private Canvas gameOverCanvas;
+    [SerializeField] private Image gameOverImage;
+    [SerializeField] private Button gameOverButton;
 
     private Tilemap castleTile;
     private Color originColor;
+
     private void Awake()
     {
         castleTile = GetComponent<Tilemap>();
         originColor = castleTile.color;
+
         if (gameOverImage != null)
         {
             gameOverImage.gameObject.SetActive(false);
-        }
-        // 슬라이더 초기화
-        if (healthSlider != null)
-        {
-            healthSlider.maxValue = maxHealth;
-            healthSlider.value = health;
-        }
-
-        if (shieldSlider != null)
-        {
-            shieldSlider.maxValue = maxShield; // 실드 슬라이더의 최대값을 설정
-            shieldSlider.value = shield;
-        }
-        else
-        {
-            Debug.LogError("Shield Slider is not assigned in the Inspector!");
         }
     }
 
     private void Start()
     {
-        health = maxHealth;
-        shield = 0; // 초기에는 실드가 없는 상태
-        hasShield = false;
-        activateShield = false;
-
         if (gameOverCanvas != null)
         {
             gameOverCanvas.enabled = false;
@@ -75,89 +41,35 @@ public class CastleWall : MonoBehaviour
             gameOverButton.enabled = false;
             gameOverButton.onClick.AddListener(OnGameOverButtonClick);
         }
-
-        // 슬라이더 초기화 상태 디버깅
-        Debug.Log("Start: hasShield set to false, shieldSlider value: " + shieldSlider.value);
     }
 
-    private void Update()
+    public void TakeDamage(float damage)
     {
-        // 매 프레임마다 hasShield의 상태를 확인하고 슬라이더 값을 업데이트
+        CastleWallManager.Instance.ApplyDamage(damage);
+
+        if (CastleWallManager.Instance.GetHealth() <= 0)
+        {
+            ShowGameOverUI();
+            Destroy(gameObject);
+        }
+    }
+
+    public void EarnShield(float duration, float shieldAmount)
+    {
+        Debug.Log("EarnShield called with duration: " + duration + " and shieldAmount: " + shieldAmount);
+        ChangeWallColor(true);  // 실드 활성화 시 색상 변경
+        CastleWallManager.Instance.EarnShield(duration, shieldAmount);
+    }
+
+    private void ChangeWallColor(bool activateShield)
+    {
         if (activateShield)
         {
-            ActivateShield();
-            activateShield = false; // 한번 실행 후 비활성화
-        }
-
-        if (hasShield)
-        {
-            UpdateShieldSlider();
+            castleTile.color = Color.cyan;
         }
         else
         {
-            if (shield != 0)
-            {
-                shield = 0;
-                UpdateShieldSlider();
-            }
-        }
-
-        UpdateHealthSlider();
-    }
-
-    public void ActivateShield()
-    {
-        hasShield = true;
-        shield = activateShieldValue;
-        UpdateShieldSlider();
-        Debug.Log("Shield activated with value: " + shield);
-    }
-
-    // 성벽이 공격당했을 때 체력을 감소시키는 함수
-    public void TakeDamage(int damage)
-    {
-        if (hasShield)
-        {
-            shield -= damage;
-            if (shield <= 0)
-            {
-                shield = 0; // 실드가 음수가 되지 않도록 설정
-                hasShield = false;
-                CustomLogger.Log("보호막이 파괴되었습니다!");
-            }
-        }
-        else
-        {
-            health -= damage;
-            if (health <= 0)
-            {
-                health = 0; // 체력이 음수가 되지 않도록 설정
-                CustomLogger.Log("성벽이 파괴되었습니다!");
-                Time.timeScale = 0f; // 게임 일시 정지
-                Debug.Log("게임 일시 정지");
-                ShowGameOverUI();
-                Destroy(gameObject);
-            }
-        }
-    }
-
-    private void UpdateHealthSlider()
-    {
-        if (healthSlider != null)
-        {
-            healthSlider.value = health;
-        }
-    }
-
-    private void UpdateShieldSlider()
-    {
-        if (shieldSlider != null)
-        {
-            shieldSlider.value = shield;
-        }
-        else
-        {
-            Debug.LogWarning("Shield Slider is not assigned in the Inspector when trying to update it!");
+            castleTile.color = originColor;
         }
     }
 
@@ -173,41 +85,5 @@ public class CastleWall : MonoBehaviour
     {
         Debug.Log("버튼 클릭됨");
         SceneManager.LoadScene("Title");
-    }
-
-    public void EarnShield(float duration, float shieldAmount)
-    {
-        Debug.Log("EarnShield called with duration: " + duration + " and shieldAmount: " + shieldAmount);
-
-        // 기존의 코루틴이 실행 중이면 중지합니다.
-        if (earnShieldCoroutine != null)
-        {
-            StopCoroutine(earnShieldCoroutine);
-        }
-        ChangeWallColor(true);
-        hasShield = true;
-        shield = shieldAmount; // 실드가 maxShield를 초과하지 않도록 설정
-        earnShieldCoroutine = StartCoroutine(ResetEarnShieldAfterDelay(duration));
-    }
-
-    private IEnumerator ResetEarnShieldAfterDelay(float delay)
-    {
-        yield return new WaitForSeconds(delay);
-        ChangeWallColor(false);
-        hasShield = false;
-        shield = 0;
-        UpdateShieldSlider();
-        Debug.Log("Shield reset to original values for: " + gameObject.name);
-    }
-    void ChangeWallColor(bool boo)
-    {
-        if (boo)
-        {
-            castleTile.color = Color.cyan;
-        }
-        else
-        {
-            castleTile.color = originColor;
-        }
     }
 }

--- a/Assets/Scripts/DefenseScripts/CastleWallManager.cs
+++ b/Assets/Scripts/DefenseScripts/CastleWallManager.cs
@@ -1,0 +1,175 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+using System.Collections;
+
+public class CastleWallManager : MonoBehaviour
+{
+    public static CastleWallManager Instance;
+
+    [SerializeField] private float maxHealth = 3000f;
+    [SerializeField] private float activateShieldValue = 80f; // 실드 활성화 시 설정할 값
+
+    public float health;
+    public float shield;
+    public bool activateShield; //activateShield가 true이면 실드 적용 + hasShield를 true로 변경
+    private Coroutine resetShieldCoroutine;
+
+    [SerializeField] private Slider healthSlider;
+    [SerializeField] private Slider shieldSlider;
+
+    [SerializeField] private bool hasShield;  // hasShield가 false가 되면 즉시 실드 무효화
+
+    private void Awake()
+    {
+        // Singleton 패턴을 사용하여 유일한 인스턴스 보장
+        if (Instance == null)
+        {
+            Instance = this;
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+
+        health = maxHealth;
+        shield = 0f;
+        hasShield = false;
+        activateShield = false;
+
+        InitializeSliders();
+    }
+
+    private void InitializeSliders()
+    {
+        if (healthSlider != null)
+        {
+            healthSlider.maxValue = maxHealth;
+            healthSlider.value = health;
+        }
+
+        if (shieldSlider != null)
+        {
+            shieldSlider.maxValue = activateShieldValue; // 실드 슬라이더의 최대값을 activateShieldValue로 설정
+            shieldSlider.value = shield;
+        }
+    }
+
+    private void Update()
+    {
+        // activateShield가 true로 설정되었을 때 실드 활성화
+        if (activateShield)
+        {
+            ActivateShield();
+            activateShield = false; // 실행 후 비활성화
+        }
+
+        // hasShield가 false가 되었을 때 실드 비활성화
+        if (!hasShield && shield > 0)
+        {
+            SetShield(0);  // 실드를 비활성화하고 초기화
+            Debug.Log("Shield deactivated.");
+        }
+    }
+
+    public void ApplyDamage(float damage)
+    {
+        if (hasShield)
+        {
+            shield -= damage;
+            if (shield <= 0)
+            {
+                damage = -shield;  // 남은 데미지를 체력에 적용
+                shield = 0;
+                hasShield = false;
+                Debug.Log("Shield destroyed!");
+            }
+            else
+            {
+                damage = 0;
+            }
+        }
+
+        health -= damage;
+        if (health <= 0)
+        {
+            health = 0;
+            HandleGameOver();
+        }
+
+        UpdateSliders();
+    }
+
+    public void EarnShield(float duration, float shieldAmount)
+    {
+        Debug.Log("EarnShield called with duration: " + duration + " and shieldAmount: " + shieldAmount);
+
+        // 기존의 실드 초기화 코루틴이 실행 중이면 중지
+        if (resetShieldCoroutine != null)
+        {
+            StopCoroutine(resetShieldCoroutine);
+        }
+
+        AddShield(shieldAmount);  // 실드 추가
+        resetShieldCoroutine = StartCoroutine(ResetEarnShieldAfterDelay(duration));  // 일정 시간 후 실드 초기화
+    }
+
+    private IEnumerator ResetEarnShieldAfterDelay(float delay)
+    {
+        yield return new WaitForSeconds(delay);
+        SetShield(0);  // 실드 초기화
+        hasShield = false;  // 실드 비활성화
+        Debug.Log("Shield reset to original values.");
+    }
+
+    public void ActivateShield()
+    {
+        SetShield(activateShieldValue);
+        hasShield = true;  // 실드 활성화 시 hasShield를 true로 설정
+        Debug.Log("Shield activated with value: " + activateShieldValue);
+    }
+
+    public void SetActivateShield(bool value)
+    {
+        activateShield = value;
+    }
+
+    public void AddShield(float shieldAmount)
+    {
+        shield = Mathf.Min(activateShieldValue, shield + shieldAmount);
+        hasShield = shield > 0;
+        UpdateSliders();
+        Debug.Log("Shield added. Current shield: " + shield);
+    }
+
+    public void SetShield(float shieldValue)
+    {
+        shield = Mathf.Clamp(shieldValue, 0, activateShieldValue);
+        hasShield = shield > 0;
+        UpdateSliders();
+        Debug.Log("Shield set to value: " + shield);
+    }
+
+    private void UpdateSliders()
+    {
+        if (healthSlider != null)
+        {
+            healthSlider.value = health;
+        }
+
+        if (shieldSlider != null)
+        {
+            shieldSlider.maxValue = activateShieldValue; // 실드 슬라이더의 최대값을 최신 activateShieldValue로 설정
+            shieldSlider.value = shield;
+        }
+    }
+
+    private void HandleGameOver()
+    {
+        Debug.Log("성벽이 파괴되었습니다! 게임 오버!");
+        Time.timeScale = 0f;  // 게임 일시 정지
+        // 게임 오버 UI를 표시하는 로직을 추가할 수 있음
+    }
+
+    public float GetHealth() => health;
+    public float GetShield() => shield;
+}

--- a/Assets/Scripts/DefenseScripts/CastleWallManager.cs
+++ b/Assets/Scripts/DefenseScripts/CastleWallManager.cs
@@ -12,7 +12,7 @@ public class CastleWallManager : MonoBehaviour
 
     public float health;
     public float shield;
-    public bool activateShield; //activateShield가 true이면 실드 적용 + hasShield를 true로 변경
+    public bool activateShield; // activateShield가 true이면 실드 적용 + hasShield를 true로 변경
     private Coroutine resetShieldCoroutine;
 
     [SerializeField] private Slider healthSlider;
@@ -20,9 +20,7 @@ public class CastleWallManager : MonoBehaviour
 
     [SerializeField] private bool hasShield; // hasShield가 false가 되면 즉시 실드 무효화
 
-    [SerializeField] private Canvas gameOverCanvas; // 게임오버 UI 관련 참조
-    [SerializeField] private Image gameOverImage;
-    [SerializeField] private Button gameOverButton;
+    private StageC stageC; // StageC 스크립트 참조
 
     private void Awake()
     {
@@ -42,7 +40,9 @@ public class CastleWallManager : MonoBehaviour
         activateShield = false;
 
         InitializeSliders();
-        InitializeGameOverUI();
+
+        // StageC 스크립트 참조 초기화
+        stageC = FindObjectOfType<StageC>();
     }
 
     private void InitializeSliders()
@@ -57,25 +57,6 @@ public class CastleWallManager : MonoBehaviour
         {
             shieldSlider.maxValue = activateShieldValue; // 실드 슬라이더의 최대값을 activateShieldValue로 설정
             shieldSlider.value = shield;
-        }
-    }
-
-    private void InitializeGameOverUI()
-    {
-        if (gameOverCanvas != null)
-        {
-            gameOverCanvas.enabled = false;
-        }
-
-        if (gameOverImage != null)
-        {
-            gameOverImage.enabled = false;
-        }
-
-        if (gameOverButton != null)
-        {
-            gameOverButton.enabled = false;
-            gameOverButton.onClick.AddListener(OnGameOverButtonClick);
         }
     }
 
@@ -118,7 +99,7 @@ public class CastleWallManager : MonoBehaviour
         if (health <= 0)
         {
             health = 0;
-            HandleGameOver();
+            HandleGameOver(); // 게임 오버 처리 호출
         }
 
         UpdateSliders();
@@ -192,28 +173,14 @@ public class CastleWallManager : MonoBehaviour
     {
         Debug.Log("성벽이 파괴되었습니다! 게임 오버!");
 
-        if (gameOverCanvas != null)
+        if (stageC != null)
         {
-            gameOverCanvas.enabled = true;
+            stageC.ShowGameOverUI(); // StageC에서 게임 오버 UI를 표시하도록 호출
         }
-
-        if (gameOverImage != null)
+        else
         {
-            gameOverImage.enabled = true;
+            Debug.LogWarning("StageC instance not found.");
         }
-
-        if (gameOverButton != null)
-        {
-            gameOverButton.enabled = true;
-        }
-
-        Time.timeScale = 0f; // 게임 일시 정지
-    }
-
-    public void OnGameOverButtonClick()
-    {
-        Debug.Log("버튼 클릭됨");
-        SceneManager.LoadScene("Title");
     }
 
     public float GetHealth() => health;

--- a/Assets/Scripts/DefenseScripts/CastleWallManager.cs
+++ b/Assets/Scripts/DefenseScripts/CastleWallManager.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using UnityEngine.UI;
 using System.Collections;
+using UnityEngine.SceneManagement;
 
 public class CastleWallManager : MonoBehaviour
 {
@@ -17,7 +18,11 @@ public class CastleWallManager : MonoBehaviour
     [SerializeField] private Slider healthSlider;
     [SerializeField] private Slider shieldSlider;
 
-    [SerializeField] private bool hasShield;  // hasShield가 false가 되면 즉시 실드 무효화
+    [SerializeField] private bool hasShield; // hasShield가 false가 되면 즉시 실드 무효화
+
+    [SerializeField] private Canvas gameOverCanvas; // 게임오버 UI 관련 참조
+    [SerializeField] private Image gameOverImage;
+    [SerializeField] private Button gameOverButton;
 
     private void Awake()
     {
@@ -37,6 +42,7 @@ public class CastleWallManager : MonoBehaviour
         activateShield = false;
 
         InitializeSliders();
+        InitializeGameOverUI();
     }
 
     private void InitializeSliders()
@@ -54,6 +60,25 @@ public class CastleWallManager : MonoBehaviour
         }
     }
 
+    private void InitializeGameOverUI()
+    {
+        if (gameOverCanvas != null)
+        {
+            gameOverCanvas.enabled = false;
+        }
+
+        if (gameOverImage != null)
+        {
+            gameOverImage.enabled = false;
+        }
+
+        if (gameOverButton != null)
+        {
+            gameOverButton.enabled = false;
+            gameOverButton.onClick.AddListener(OnGameOverButtonClick);
+        }
+    }
+
     private void Update()
     {
         // activateShield가 true로 설정되었을 때 실드 활성화
@@ -66,7 +91,7 @@ public class CastleWallManager : MonoBehaviour
         // hasShield가 false가 되었을 때 실드 비활성화
         if (!hasShield && shield > 0)
         {
-            SetShield(0);  // 실드를 비활성화하고 초기화
+            SetShield(0); // 실드를 비활성화하고 초기화
             Debug.Log("Shield deactivated.");
         }
     }
@@ -78,7 +103,7 @@ public class CastleWallManager : MonoBehaviour
             shield -= damage;
             if (shield <= 0)
             {
-                damage = -shield;  // 남은 데미지를 체력에 적용
+                damage = -shield; // 남은 데미지를 체력에 적용
                 shield = 0;
                 hasShield = false;
                 Debug.Log("Shield destroyed!");
@@ -109,22 +134,22 @@ public class CastleWallManager : MonoBehaviour
             StopCoroutine(resetShieldCoroutine);
         }
 
-        AddShield(shieldAmount);  // 실드 추가
-        resetShieldCoroutine = StartCoroutine(ResetEarnShieldAfterDelay(duration));  // 일정 시간 후 실드 초기화
+        AddShield(shieldAmount); // 실드 추가
+        resetShieldCoroutine = StartCoroutine(ResetEarnShieldAfterDelay(duration)); // 일정 시간 후 실드 초기화
     }
 
     private IEnumerator ResetEarnShieldAfterDelay(float delay)
     {
         yield return new WaitForSeconds(delay);
-        SetShield(0);  // 실드 초기화
-        hasShield = false;  // 실드 비활성화
+        SetShield(0); // 실드 초기화
+        hasShield = false; // 실드 비활성화
         Debug.Log("Shield reset to original values.");
     }
 
     public void ActivateShield()
     {
         SetShield(activateShieldValue);
-        hasShield = true;  // 실드 활성화 시 hasShield를 true로 설정
+        hasShield = true; // 실드 활성화 시 hasShield를 true로 설정
         Debug.Log("Shield activated with value: " + activateShieldValue);
     }
 
@@ -166,8 +191,29 @@ public class CastleWallManager : MonoBehaviour
     private void HandleGameOver()
     {
         Debug.Log("성벽이 파괴되었습니다! 게임 오버!");
-        Time.timeScale = 0f;  // 게임 일시 정지
-        // 게임 오버 UI를 표시하는 로직을 추가할 수 있음
+
+        if (gameOverCanvas != null)
+        {
+            gameOverCanvas.enabled = true;
+        }
+
+        if (gameOverImage != null)
+        {
+            gameOverImage.enabled = true;
+        }
+
+        if (gameOverButton != null)
+        {
+            gameOverButton.enabled = true;
+        }
+
+        Time.timeScale = 0f; // 게임 일시 정지
+    }
+
+    public void OnGameOverButtonClick()
+    {
+        Debug.Log("버튼 클릭됨");
+        SceneManager.LoadScene("Title");
     }
 
     public float GetHealth() => health;

--- a/Assets/Scripts/DefenseScripts/CastleWallManager.cs.meta
+++ b/Assets/Scripts/DefenseScripts/CastleWallManager.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 6d05be8185cf431ab9256b7c00297140
+timeCreated: 1723348799

--- a/Assets/Scripts/DefenseScripts/DarkElfSpawner.cs
+++ b/Assets/Scripts/DefenseScripts/DarkElfSpawner.cs
@@ -206,6 +206,6 @@ public class DarkElfSpawner : MonoBehaviour
             boss =Instantiate(bossPrefab, spawnPosition, Quaternion.Euler(0, 180, 0), transform);
         }
 
-        boss.transform.localScale *= 2;
+        boss.transform.localScale *= 3;
     }
 }

--- a/Assets/Scripts/DefenseScripts/StageC.cs
+++ b/Assets/Scripts/DefenseScripts/StageC.cs
@@ -1,0 +1,61 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.SceneManagement;
+
+public class StageC : MonoBehaviour
+{
+    [SerializeField] private Canvas gameOverCanvas; // 게임오버 UI 관련 참조
+    [SerializeField] private Image gameOverImage;
+    [SerializeField] private Button gameOverButton;
+
+    private void Awake()
+    {
+        // 초기화
+        InitializeGameOverUI();
+    }
+
+    private void InitializeGameOverUI()
+    {
+        if (gameOverCanvas != null)
+        {
+            gameOverCanvas.enabled = false;
+        }
+
+        if (gameOverImage != null)
+        {
+            gameOverImage.enabled = false;
+        }
+
+        if (gameOverButton != null)
+        {
+            gameOverButton.enabled = false;
+            gameOverButton.onClick.AddListener(OnGameOverButtonClick);
+        }
+    }
+
+    public void ShowGameOverUI()
+    {
+        if (gameOverCanvas != null)
+        {
+            gameOverCanvas.enabled = true;
+        }
+
+        if (gameOverImage != null)
+        {
+            gameOverImage.enabled = true;
+        }
+
+        if (gameOverButton != null)
+        {
+            gameOverButton.enabled = true;
+        }
+
+        Time.timeScale = 0f; // 게임 일시 정지
+    }
+
+    private void OnGameOverButtonClick()
+    {
+        Debug.Log("버튼 클릭됨");
+        SceneManager.LoadScene("Title");
+    }
+}

--- a/Assets/Scripts/DefenseScripts/StageC.cs.meta
+++ b/Assets/Scripts/DefenseScripts/StageC.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 238f93112c684bf1b27abfdd679508a2
+timeCreated: 1723364485


### PR DESCRIPTION
Add 2 Gameobject in Defense Scene
Stage Controller, Wall HP Controller

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ゲームオーバーUIを表示する新しい管理クラスを追加。
	- 壁のHP管理を一本化する「CastleWallManager」クラスを導入し、健康とシールドの管理を強化。
	- ボスのスケールを3倍に変更。
- **変更点**
	- ユーザーインターフェースのレイアウトが調整され、ゲーム内の視覚表現が改善。
	- 壁のダメージ管理とシールド機能が簡素化され、処理が効率化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->